### PR TITLE
fix(logistics): correct order_sn_list → order_list for 3 shipping document param types

### DIFF
--- a/src/__tests__/managers/logistics.manager.test.ts
+++ b/src/__tests__/managers/logistics.manager.test.ts
@@ -894,7 +894,7 @@ describe("LogisticsManager", () => {
       mockShopeeFetch.mockResolvedValue(mockResponse);
 
       await logisticsManager.createShippingDocument({
-        order_sn_list: ["ORDER1"],
+        order_list: [{ order_sn: "ORDER1", tracking_number: "TRK123" }],
         shipping_document_type: "NORMAL_AIR_WAYBILL",
       });
 
@@ -904,7 +904,7 @@ describe("LogisticsManager", () => {
         {
           method: "POST",
           auth: true,
-          body: { order_sn_list: ["ORDER1"], shipping_document_type: "NORMAL_AIR_WAYBILL" },
+          body: { order_list: [{ order_sn: "ORDER1", tracking_number: "TRK123" }], shipping_document_type: "NORMAL_AIR_WAYBILL" },
         }
       );
     });
@@ -925,7 +925,7 @@ describe("LogisticsManager", () => {
       const mockResponse = { request_id: "test", error: "", message: "", response: {} };
       mockShopeeFetch.mockResolvedValue(mockResponse);
 
-      await logisticsManager.getShippingDocumentParameter({ order_sn_list: ["ORDER1"] });
+      await logisticsManager.getShippingDocumentParameter({ order_list: [{ order_sn: "ORDER1" }] });
 
       expect(mockShopeeFetch).toHaveBeenCalled();
     });
@@ -935,7 +935,7 @@ describe("LogisticsManager", () => {
       mockShopeeFetch.mockResolvedValue(mockResponse);
 
       await logisticsManager.getShippingDocumentResult({
-        order_sn_list: ["ORDER1"],
+        order_list: [{ order_sn: "ORDER1" }],
         shipping_document_type: "NORMAL_AIR_WAYBILL",
       });
 

--- a/src/__tests__/managers/logistics.manager.test.ts
+++ b/src/__tests__/managers/logistics.manager.test.ts
@@ -904,7 +904,10 @@ describe("LogisticsManager", () => {
         {
           method: "POST",
           auth: true,
-          body: { order_list: [{ order_sn: "ORDER1", tracking_number: "TRK123" }], shipping_document_type: "NORMAL_AIR_WAYBILL" },
+          body: {
+            order_list: [{ order_sn: "ORDER1", tracking_number: "TRK123" }],
+            shipping_document_type: "NORMAL_AIR_WAYBILL",
+          },
         }
       );
     });

--- a/src/schemas/logistics.ts
+++ b/src/schemas/logistics.ts
@@ -839,10 +839,19 @@ export enum ShippingDocumentType {
  * Parameters for create shipping document
  */
 export type CreateShippingDocumentParams = {
-  /** List of order SNs */
-  order_sn_list: string[];
+  /** List of orders to create shipping document for. limit [1, 50] */
+  order_list: Array<{
+    /** Shopee's unique identifier for an order */
+    order_sn: string;
+    /** Shopee's unique identifier for the package under an order */
+    package_number?: string;
+    /** The tracking number of the order. Required except for channels that allow printing before arrangement */
+    tracking_number?: string;
+    /** The type of shipping document */
+    shipping_document_type?: string;
+  }>;
   /** Document type */
-  shipping_document_type: string;
+  shipping_document_type?: string;
 } & Record<string, string | number | boolean | object | null | undefined>;
 
 /**
@@ -876,9 +885,14 @@ export type DownloadShippingDocumentResponse = Buffer;
  * Parameters for get shipping document parameter
  */
 export type GetShippingDocumentParameterParams = {
-  /** List of order SNs */
-  order_sn_list: string[];
-} & Record<string, string | number | boolean | null | undefined>;
+  /** List of orders to get shipping document parameters for. limit [1, 50] */
+  order_list: Array<{
+    /** Shopee's unique identifier for an order */
+    order_sn: string;
+    /** Shopee's unique identifier for the package under an order */
+    package_number?: string;
+  }>;
+} & Record<string, string | number | boolean | object | null | undefined>;
 
 /**
  * Response for get shipping document parameter API
@@ -896,11 +910,18 @@ export interface GetShippingDocumentParameterResponse extends BaseResponse {
  * Parameters for get shipping document result
  */
 export type GetShippingDocumentResultParams = {
-  /** List of order SNs */
-  order_sn_list: string[];
+  /** List of orders to query shipping document status for. limit [1, 50] */
+  order_list: Array<{
+    /** Shopee's unique identifier for an order */
+    order_sn: string;
+    /** Shopee's unique identifier for the package under an order */
+    package_number?: string;
+    /** The type of shipping document */
+    shipping_document_type?: string;
+  }>;
   /** Document type */
-  shipping_document_type: string;
-} & Record<string, string | number | boolean | null | undefined>;
+  shipping_document_type?: string;
+} & Record<string, string | number | boolean | object | null | undefined>;
 
 /**
  * Shipping document result item


### PR DESCRIPTION
## Summary

Fixes #170

Three `*Params` types in `src/schemas/logistics.ts` declare `order_sn_list: string[]` but the Shopee API requires `order_list: [{order_sn, ...}]`. This causes a runtime `error_param: order_list is a required field` error for anyone calling these methods.

**Root cause:** The source JSON schemas in `schemas/` already define the correct field name (`order_list`). This appears to be a type generation artifact — the generated TypeScript types picked up the wrong field name.

**Affected types:**

| Type | Before | After |
|---|---|---|
| `CreateShippingDocumentParams` | `order_sn_list: string[]` | `order_list: Array<{order_sn, package_number?, tracking_number?, shipping_document_type?}>` |
| `GetShippingDocumentParameterParams` | `order_sn_list: string[]` | `order_list: Array<{order_sn, package_number?}>` |
| `GetShippingDocumentResultParams` | `order_sn_list: string[]` | `order_list: Array<{order_sn, package_number?, shipping_document_type?}>` |

Note: `tracking_number` inside `CreateShippingDocumentParams.order_list` is documented as required except for channels that allow pre-arrangement printing — omitting it returns `logistics.tracking_number_invalid`.

## Verification

Confirmed against:
- The repo's own JSON schemas (`schemas/v2.logistics.create_shipping_document.json`, `schemas/v2.logistics.get_shipping_document_result.json`, `schemas/v2.logistics.get_shipping_document_parameter.json`)
- The official Shopee Open Platform API docs
- Live Shopee SG API calls (region: GLOBAL) — using `order_list` resolves the error

## Changes

- `src/schemas/logistics.ts` — fix three param types
- `src/__tests__/managers/logistics.manager.test.ts` — update tests to use correct field names

All 56 logistics manager tests pass.